### PR TITLE
dep bumps, dropping target framework to widen compat

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="17.2.32" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="17.3.48" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="4.0.0" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ services.AddMassTransit(x =>
 
 # Important ❗
 
-This library is currently using the __Datadog.Tracer version 1.31.0__, so if you're doing automatic and custom instrumentation, make sure to have the same version of the [Datadog Tracer ](https://github.com/DataDog/dd-trace-dotnet/releases) binary installed on your system, as mentioned by the [documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#custom-instrumentation). Speaking of the Datadog APM documentation, I recommend reading it fully to avoid any gotchas.
+This library is currently using the __Datadog.Tracer version 2.17.0__, so if you're doing automatic and custom instrumentation, make sure to have the same version of the [Datadog Tracer ](https://github.com/DataDog/dd-trace-dotnet/releases) binary installed on your system, as mentioned by the [documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#custom-instrumentation). Speaking of the Datadog APM documentation, I recommend reading it fully to avoid any gotchas.

--- a/Source/Datadog.Trace.MassTransit/Configuration/DatadogTracingPipeSpecification.cs
+++ b/Source/Datadog.Trace.MassTransit/Configuration/DatadogTracingPipeSpecification.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Datadog.Trace.MassTransit.Filters;
-using GreenPipes;
+﻿using Datadog.Trace.MassTransit.Filters;
 using MassTransit;
+using MassTransit.Configuration;
 
 namespace Datadog.Trace.MassTransit.Configuration
 {

--- a/Source/Datadog.Trace.MassTransit/Datadog.Trace.MassTransit.csproj
+++ b/Source/Datadog.Trace.MassTransit/Datadog.Trace.MassTransit.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="1.31.0" />
-    <PackageReference Include="MassTransit" Version="7.3.1" />
+    <PackageReference Include="Datadog.Trace" Version="2.17.0" />
+    <PackageReference Include="MassTransit" Version="8.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 

--- a/Source/Datadog.Trace.MassTransit/DatadogTraceSpanHelper.cs
+++ b/Source/Datadog.Trace.MassTransit/DatadogTraceSpanHelper.cs
@@ -6,24 +6,32 @@ namespace Datadog.Trace.MassTransit
     {
         private const string ServiceName = "MassTransit";
 
-        internal static void SetSpanTags(MessageContext context, Scope scope)
+        internal static void SetSpanTags(MessageContext context, IScope scope)
         {
             scope.Span.SetTag(DatadogSpanTag.MessageId, context.MessageId.ToString());
-            scope.Span.SetTag(DatadogSpanTag.DestinationHost, context.DestinationAddress.Host);
-            scope.Span.SetTag(DatadogSpanTag.DestinationEndpoint, context.DestinationAddress.AbsolutePath);
             scope.Span.SetTag(DatadogSpanTag.MessageConversationId, context.ConversationId.ToString());
-            scope.Span.ResourceName = context.DestinationAddress.AbsolutePath;
             scope.Span.ServiceName = ServiceName;
+
+            if (context.DestinationAddress != null)
+            {
+                scope.Span.SetTag(DatadogSpanTag.DestinationHost, context.DestinationAddress.Host);
+                scope.Span.SetTag(DatadogSpanTag.DestinationEndpoint, context.DestinationAddress.AbsolutePath);
+                scope.Span.ResourceName = context.DestinationAddress.AbsolutePath;
+            }
         }
 
-        internal static void SetSpanTags(SendContext context, Scope scope)
+        internal static void SetSpanTags(SendContext context, IScope scope)
         {
             scope.Span.SetTag(DatadogSpanTag.MessageId, context.MessageId.ToString());
-            scope.Span.SetTag(DatadogSpanTag.DestinationHost, context.DestinationAddress.Host);
-            scope.Span.SetTag(DatadogSpanTag.DestinationEndpoint, context.DestinationAddress.AbsolutePath);
             scope.Span.SetTag(DatadogSpanTag.MessageConversationId, context.ConversationId.ToString());
-            scope.Span.ResourceName = context.DestinationAddress.AbsolutePath;
             scope.Span.ServiceName = ServiceName;
+
+            if (context.DestinationAddress != null)
+            {
+                scope.Span.SetTag(DatadogSpanTag.DestinationHost, context.DestinationAddress.Host);
+                scope.Span.SetTag(DatadogSpanTag.DestinationEndpoint, context.DestinationAddress.AbsolutePath);
+                scope.Span.ResourceName = context.DestinationAddress.AbsolutePath;
+            }
         }
     }
 }

--- a/Source/Datadog.Trace.MassTransit/Filters/DatadogTraceConsumeFilter.cs
+++ b/Source/Datadog.Trace.MassTransit/Filters/DatadogTraceConsumeFilter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using GreenPipes;
-using MassTransit;
+﻿using MassTransit;
 
 namespace Datadog.Trace.MassTransit.Filters
 {
@@ -16,7 +13,7 @@ namespace Datadog.Trace.MassTransit.Filters
         {
             ulong? parentSpanId = null;
             ulong? traceId = null;
-            SpanContext? propagatedContext = null;
+            ISpanContext? propagatedContext = null;
 
             if (context.Headers.TryGetHeader(MassTransitMessageHeader.TraceId, out var traceString))
             {
@@ -33,7 +30,11 @@ namespace Datadog.Trace.MassTransit.Filters
                 propagatedContext = new SpanContext(traceId, parentSpanId.Value);
             }
 
-            using (var scope = Tracer.Instance.StartActive(MassTransitOperationName.Transport.Receive, propagatedContext))
+            var spanCreationSettings = new SpanCreationSettings
+            {
+                Parent = propagatedContext
+            };
+            using (var scope = Tracer.Instance.StartActive(MassTransitOperationName.Transport.Receive, spanCreationSettings))
             {
                 DatadogTraceSpanHelper.SetSpanTags(context, scope);
                 await next.Send(context);

--- a/Source/Datadog.Trace.MassTransit/Filters/DatadogTracePublishFilter.cs
+++ b/Source/Datadog.Trace.MassTransit/Filters/DatadogTracePublishFilter.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using GreenPipes;
-using MassTransit;
+﻿using MassTransit;
 
 namespace Datadog.Trace.MassTransit.Filters
 {
@@ -16,7 +13,7 @@ namespace Datadog.Trace.MassTransit.Filters
         {
             ulong? parentSpanId = null;
             ulong? traceId = null;
-            SpanContext? propagatedContext = null;
+            ISpanContext? propagatedContext = null;
 
             if (context.Headers.TryGetHeader(MassTransitMessageHeader.TraceId, out var traceString))
             {
@@ -33,7 +30,11 @@ namespace Datadog.Trace.MassTransit.Filters
                 propagatedContext = new SpanContext(traceId.Value, parentSpanId.Value);
             }
 
-            using (var scope = Tracer.Instance.StartActive(MassTransitOperationName.Transport.Send, propagatedContext))
+            var spanCreationSettings = new SpanCreationSettings
+            {
+                Parent = propagatedContext
+            };
+            using (var scope = Tracer.Instance.StartActive(MassTransitOperationName.Transport.Send, spanCreationSettings))
             {
                 if (propagatedContext == null)
                 {
@@ -52,7 +53,7 @@ namespace Datadog.Trace.MassTransit.Filters
         {
             ulong? parentSpanId = null;
             ulong? traceId = null;
-            SpanContext? propagatedContext = null;
+            ISpanContext? propagatedContext = null;
 
             if (context.Headers.TryGetHeader(MassTransitMessageHeader.TraceId, out var traceString))
             {
@@ -69,7 +70,11 @@ namespace Datadog.Trace.MassTransit.Filters
                 propagatedContext = new SpanContext(traceId.Value, parentSpanId.Value);
             }
 
-            using (var scope = Tracer.Instance.StartActive(MassTransitOperationName.Transport.Send, propagatedContext))
+            var spanCreationSettings = new SpanCreationSettings
+            {
+                Parent = propagatedContext
+            };
+            using (var scope = Tracer.Instance.StartActive(MassTransitOperationName.Transport.Send, spanCreationSettings))
             {
                 if (propagatedContext == null)
                 {

--- a/Source/Datadog.Trace.MassTransit/MassTransitMessageHeaderHelper.cs
+++ b/Source/Datadog.Trace.MassTransit/MassTransitMessageHeaderHelper.cs
@@ -6,14 +6,28 @@ namespace Datadog.Trace.MassTransit
     {
         internal static void SetHeaders(PublishContext context, ulong? parentSpanId, ulong? traceId)
         {
-            context.Headers.Set(MassTransitMessageHeader.TraceId, traceId);
-            context.Headers.Set(MassTransitMessageHeader.ParentSpanId, parentSpanId);
+            if (traceId != null)
+            {
+                context.Headers.Set(MassTransitMessageHeader.TraceId, traceId.ToString());
+            }
+
+            if (parentSpanId != null)
+            {
+                context.Headers.Set(MassTransitMessageHeader.ParentSpanId, parentSpanId.ToString());
+            }
         }
 
         internal static void SetHeaders(SendContext context, ulong? parentSpanId, ulong? traceId)
         {
-            context.Headers.Set(MassTransitMessageHeader.TraceId, traceId);
-            context.Headers.Set(MassTransitMessageHeader.ParentSpanId, parentSpanId);
+            if (traceId != null)
+            {
+                context.Headers.Set(MassTransitMessageHeader.TraceId, traceId.ToString());
+            }
+
+            if (parentSpanId != null)
+            {
+                context.Headers.Set(MassTransitMessageHeader.ParentSpanId, parentSpanId.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
- Few basic dependency bumps
- dropping target framework to `netstandard2.0` to increase compatibility (nothing specific in this library that's forcing it to be as high as `net5` - can use this in code bases that are shared with full framework apps now)
- dealt with a few null checks that I saw warnings on
- double check me on what were the breaking changes in DD around `Scope` visibility / `SpanCreationSettings` concept
